### PR TITLE
Replace mention of Marcus' domain with JSOxford's own

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function build() {
     .metadata({
       site : {
         title: 'JSOxford',
-        url: 'http://jsoxford-next.marcusnoble.co.uk', //'https://jsoxford.com',
+        url: 'https://jsoxford.com',
         description: 'A regular meetup of JavaScript enthusiasts every other month in Oxford, UK.'
       },
       meetup: meetupDetails


### PR DESCRIPTION
I'm not sure this is a thing -- please close this PR if not -- but I noticed the mention of Marcus' domain in the configuration and wondered if it was a holdover from the site redesign.